### PR TITLE
Add formatting pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "res:dev": "rescript -w",
     "res:format": "rescript format -all",
     "test": "npm run res:build && pta 'tests/*.mjs'",
-    "test-watch": "onchange --initial '{tests,src}/*.mjs' -- pta 'tests/*.mjs'"
+    "test-watch": "onchange --initial '{tests,src}/*.mjs' -- pta 'tests/*.mjs'",
+    "prepare": "husky"
   },
   "dependencies": {
     "@rescript/react": "^0.13.1",
@@ -33,10 +34,15 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.2.3",
     "onchange": "^7.1.0",
     "pta": "^1.3.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"
+  },
+  "lint-staged": {
+    "*.res": "rescript format"
   }
 }


### PR DESCRIPTION
Originally was going to make this part of #9 but figure they're independent enough to separate out. After running `npm install` again, this should format staged files automatically before committing them. Would be good if someone could double check this on their machine before we merge though.